### PR TITLE
fix danger lint warning

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    danger-checkstyle_format (0.0.3)
+    danger-checkstyle_format (0.0.4)
       danger-plugin-api (~> 1.0)
       ox (~> 2.0)
 

--- a/lib/checkstyle_format/checkstyle_error.rb
+++ b/lib/checkstyle_format/checkstyle_error.rb
@@ -1,0 +1,12 @@
+CheckstyleError = Struct.new(:file_name, :line, :column, :severity, :message, :source) do
+  def self.generate(node, parent_node, base_path)
+    CheckstyleError.new(
+      parent_node[:name].sub(/^#{base_path}/, ""),
+      node[:line].to_i,
+      node[:column].nil? ? nil : node[:column].to_i,
+      node[:severity],
+      node[:message],
+      node[:source]
+    )
+  end
+end

--- a/lib/checkstyle_format/gem_version.rb
+++ b/lib/checkstyle_format/gem_version.rb
@@ -1,3 +1,3 @@
 module CheckstyleFormat
-  VERSION = "0.0.3".freeze
+  VERSION = "0.0.4".freeze
 end

--- a/lib/checkstyle_format/plugin.rb
+++ b/lib/checkstyle_format/plugin.rb
@@ -1,3 +1,5 @@
+require_relative "checkstyle_error"
+
 module Danger
   # Danger plugin for checkstyle formatted xml file.
   #
@@ -27,19 +29,6 @@ module Danger
         send_inline_comment(errors)
       else
         raise "not implemented." # TODO: not implemented.
-      end
-    end
-
-    CheckstyleError = Struct.new(:file_name, :line, :column, :severity, :message, :source) do
-      def self.generate(node, parent_node, base_path)
-        CheckstyleError.new(
-          parent_node[:name].sub(/^#{base_path}/, ""),
-          node[:line].to_i,
-          node[:column].nil? ? nil : node[:column].to_i,
-          node[:severity],
-          node[:message],
-          node[:source]
-        )
       end
     end
 

--- a/spec/checkstyle_format_spec.rb
+++ b/spec/checkstyle_format_spec.rb
@@ -15,8 +15,8 @@ module Danger
       describe ".send_inline_comment" do
         it "calls certain argument" do
           errors = [
-            DangerCheckstyleFormat::CheckstyleError.new("XXX.java", 1, nil, "error", "test message1.", "source"),
-            DangerCheckstyleFormat::CheckstyleError.new("YYY.java", 2, nil, "error", "test message2.", "source")
+            CheckstyleError.new("XXX.java", 1, nil, "error", "test message1.", "source"),
+            CheckstyleError.new("YYY.java", 2, nil, "error", "test message2.", "source")
           ]
           @checkstyle_format.send(:send_inline_comment, errors)
           expect(@checkstyle_format.status_report[:warnings]).to eq(["test message1.", "test message2."])


### PR DESCRIPTION
I executed `bundle exec danger plugins lint danger-checkstyle_format`, below warning is shown.

```
/var/folders/qy/jqp_yybx5fn9m9ygm_97lpym0000gn/T/d20170905-68773-1l30app/vendor/gems/ruby/2.4.0/gems/danger-checkstyle_format-0.0.3/lib/checkstyle_format/plugin.rb:33: warning: already initialized constant Danger::DangerCheckstyleFormat::CheckstyleError
/Users/ishikuranoboru/.ghq/github.com/noboru-i/danger-checkstyle_format/lib/checkstyle_format/plugin.rb:33: warning: previous definition of CheckstyleError was here
```